### PR TITLE
Support `silent` argument in `config.from_envvar`

### DIFF
--- a/src/quart/config.py
+++ b/src/quart/config.py
@@ -106,7 +106,9 @@ class Config(dict):
             app.config.from_pyfile(filename)
         """
         value = os.environ.get(variable_name)
-        if value is None and not silent:
+        if value is None:
+            if silent:
+                return False
             raise RuntimeError(
                 f"Environment variable {variable_name} is not present, cannot load config"
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,6 +135,17 @@ def test_config_from_envvar() -> None:
     _check_standard_config(config)
 
 
+def test_config_from_envvar_not_set_with_silent() -> None:
+    config = Config(Path(__file__).parent)
+    config.from_envvar("UNKNOWN_CONFIG", silent=True)
+
+
+def test_config_from_envvar_not_set_without_silent() -> None:
+    config = Config(Path(__file__).parent)
+    with pytest.raises(RuntimeError):
+        config.from_envvar("UNKNOWN_CONFIG")
+
+
 def test_config_from_json() -> None:
     config = Config(Path(__file__).parent)
     config.from_json("assets/config.json")


### PR DESCRIPTION
Proposed solution for issue #154.