### PR TITLE
Require click >= 8.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@
 * Adopt the Flask JSON provider interface, use instead of JSON
   encoders and decoders.
 * Switch to being a Pallets project.
+* Requires at least v8 of click.
 
 
 0.17.0 2022-03-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ documentation = "https://quart.palletsprojects.com"
 python = ">=3.7"
 aiofiles = "*"
 blinker = "*"
-click = "*"
+click = ">=8.0.0"
 hypercorn = ">=0.11.2"
 importlib_metadata = { version = "*", python = "<3.10" }
 itsdangerous = "*"


### PR DESCRIPTION
This PR adds a requirement that click be at least v8.

- fixes #177

Checklist:

- [ ] ~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
- [ ] ~Add or update relevant docs, in the docs folder and in code.~
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] ~Add `.. versionchanged::` entries in any relevant code docs.~
- [ ] ~Run `pre-commit` hooks and fix any issues.~
- [x] Run `pytest` and `tox`, no tests failed.
