### PR TITLE
Fix signal handling for Windows and Unix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.18.3 2022-10-05
+-----------------
+
+* Bugfix use add_signal_handler for Unix signals and signal.signal for Windows signals.
+
 0.18.2 2022-10-04
 -----------------
 

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -1371,9 +1371,13 @@ class Quart(Scaffold):
         def _signal_handler(*_: Any) -> None:
             shutdown_event.set()
 
-        for signal_name in {"SIGINT", "SIGTERM", "SIGBREAK"}:
-            if hasattr(signal, signal_name):
-                loop.add_signal_handler(getattr(signal, signal_name), _signal_handler)
+        try:
+            for signal_name in {"SIGINT", "SIGTERM"}:
+                if hasattr(signal, signal_name):
+                    loop.add_signal_handler(getattr(signal, signal_name), _signal_handler)
+        except (AttributeError, NotImplementedError):
+            pass
+        signal.signal(getattr(signal, "SIGBREAK"), _signal_handler)
 
         server_name = self.config.get("SERVER_NAME")
         sn_host = None


### PR DESCRIPTION
Change : Using loop.add_signal_handler for Unix signals with try/except in order to fail quietly on Windows; then use the signal.signal for Windows signal.

- fixes #193

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

Clearly I don't know how to test such things...