### PR TITLE
Docs api_tutorial.rst add missing app instantiation

### DIFF
--- a/docs/tutorials/api_tutorial.rst
+++ b/docs/tutorials/api_tutorial.rst
@@ -143,6 +143,7 @@ We can then add schemas for a Todo object by adding the following to
     from dataclasses import dataclass
     from datetime import datetime
 
+    from quart import Quart
     from quart_schema import QuartSchema, validate_request, validate_response
     
     app = Quart(__name__)

--- a/docs/tutorials/api_tutorial.rst
+++ b/docs/tutorials/api_tutorial.rst
@@ -144,7 +144,9 @@ We can then add schemas for a Todo object by adding the following to
     from datetime import datetime
 
     from quart_schema import QuartSchema, validate_request, validate_response
-
+    
+    app = Quart(__name__)
+    
     QuartSchema(app)
 
     @dataclass


### PR DESCRIPTION
Tiny docs update to help learners not trip up reading the docs missing `app = Quart(__name__)`