### PR TITLE
Extension `quart-session-openid` was rebranded to `quart-keycloak`

### DIFF
--- a/docs/how_to_guides/quart_extensions.rst
+++ b/docs/how_to_guides/quart_extensions.rst
@@ -29,8 +29,8 @@ here,
   (MongoDB) support for Quart applications.
 - `Quart-OpenApi <https://github.com/factset/quart-openapi/>`_ RESTful
   API building.
-- `Quart-Session-OpenID <https://github.com/sanderfoobar/quart-session-openid>`_
-  Support for OAuth2 OpenID Connect (OIDC).
+- `Quart-Keycloak <https://github.com/kroketio/quart-keycloak>`_
+  Support for Keycloak's OAuth2 OpenID Connect (OIDC).
 - `Quart-Rapidoc <https://github.com/marirs/quart-rapidoc>`_ API
   documentation from OpenAPI Specification.
 - `Quart-Rate-Limiter


### PR DESCRIPTION
Previously this extension was known as `quart-session-openid` and made an effort to support multiple OpenID servers but it turns out that everyone has their own interpretation of the OpenID spec so IdPs tended to vary which caused breakage. Even between Keycloak versions there are small (but breaking) changes - so it was decided to narrow the scope, rebrand to `quart-keycloak` and focus on modern Keycloak versions.