### PR TITLE
Fix type annotation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.18.3 2022-10-08
 -----------------
 
+* Corrected quart.json.loads type annotation.
 * Bugfix signal handling on Windows.
 * Bugfix add missing globals to Flask-Patch.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.18.3 2022-10-08
 -----------------
 
-* Corrected quart.json.loads type annotation.
+* Fixed Issue #206. Corrected quart.json.loads type annotation.
 * Bugfix signal handling on Windows.
 * Bugfix add missing globals to Flask-Patch.
 

--- a/src/quart/json/__init__.py
+++ b/src/quart/json/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, IO, TYPE_CHECKING
+from typing import Any, IO, TYPE_CHECKING, Union
 
 from .provider import _default
 from ..globals import current_app
@@ -20,7 +20,7 @@ def dump(object_: Any, fp: IO[str], **kwargs: Any) -> None:
     json.dump(object_, fp, **kwargs)
 
 
-def loads(object_: str, **kwargs: Any) -> Any:
+def loads(object_: Union[str, bytes], **kwargs: Any) -> Any:
     return json.loads(object_, **kwargs)
 
 


### PR DESCRIPTION
Fix for incorrect type annotation in `quart.json.loads`. From `object_: str` to `object_: Union[str, bytes]`

- fixes #206

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
