### PR TITLE
Consistently use Line Feed  without Carriage Return  in generating SSE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,5 @@
+* Fixed Issue #219. Use only CR in SSE documentation.
+
 0.18.3 2022-10-08
 -----------------
 

--- a/docs/how_to_guides/server_sent_events.rst
+++ b/docs/how_to_guides/server_sent_events.rst
@@ -30,7 +30,7 @@ helper class:
                 message = f"{message}\nid: {self.id}"
             if self.retry is not None:
                 message = f"{message}\nretry: {self.retry}"
-            message = f"{message}\r\n\r\n"
+            message = f"{message}\n\n"
             return message.encode('utf-8')
 
 To use a GET route that returns a streaming generator is


### PR DESCRIPTION
- fixes # 219

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
