### PR TITLE
Fix typo in Config docstring

### DIFF
--- a/src/quart/config.py
+++ b/src/quart/config.py
@@ -290,7 +290,7 @@ class Config(dict):
 
             config = {'FOO': 'bar'}
             app.config.from_mapping(config)
-            app.config.form_mapping(FOO='bar')
+            app.config.from_mapping(FOO='bar')
 
         Arguments:
             mapping: Optionally a mapping object.


### PR DESCRIPTION
Typo as seen [here](https://quart.palletsprojects.com/en/latest/reference/source/quart.config.html#quart.config.Config.from_mapping) :slightly_smiling_face: 

## :snake: :man_juggling: 