### PR TITLE
Add click and request.values to patch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,4 @@
+* Fixed Issue #236. Add cli.click and globals request.values.
 * Fixed Issue #219. Use only CR in SSE documentation.
 
 0.18.4 2023-04-09

--- a/src/quart/flask_patch/cli.py
+++ b/src/quart/flask_patch/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from quart.cli import (  # noqa: F401
     AppGroup,
+    click,
     QuartGroup,
     run_command,
     ScriptInfo,

--- a/src/quart/flask_patch/globals.py
+++ b/src/quart/flask_patch/globals.py
@@ -33,6 +33,10 @@ class FlaskRequestProxy(LocalProxy):
         return sync_with_context(self._get_current_object().files)
 
     @property
+    def values(self) -> MultiDict:
+        return sync_with_context(self._get_current_object().values)
+
+    @property
     def json(self) -> Any:
         return sync_with_context(self._get_current_object().json)
 


### PR DESCRIPTION
This adds cli.click and globals.request.values to the Flask compatibility patches.

- fixes #236 

I have not executed the checklist, because:

- I wasn't able to successfully run the tests with my pre-modification code
- I didn't have the time available to write and debug new tests

Please feel free to reject this PR and to treat it as clarification only for #236 . 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
