### PR TITLE
Update quart_extensions.rst

### DIFF
--- a/docs/how_to_guides/quart_extensions.rst
+++ b/docs/how_to_guides/quart_extensions.rst
@@ -38,7 +38,7 @@ here,
   support.
 - `Webargs-Quart <https://github.com/esfoobar/webargs-quart>`_ Webargs
   parsing for Quart.
-- `Quart-WTF <https://github.com/Quart-Addons/quart-wtf`_ Simple integration of Quart
+- `Quart-WTF <https://github.com/Quart-Addons/quart-wtf>`_ Simple integration of Quart
   and WTForms. Including CSRF and file uploading.
 - `Quart-Schema <https://github.com/pgjones/quart-schema>`_ Schema
   validation and auto-generated API documentation.


### PR DESCRIPTION
Fixed link to Quart-WTF, since the hyperlink was not working. This was an error with the original commit.
