### PR TITLE
corrected typing hint for abort method at helpers.py

### DIFF
--- a/src/quart/helpers.py
+++ b/src/quart/helpers.py
@@ -390,7 +390,7 @@ def _split_blueprint_path(name: str) -> List[str]:
     return bps
 
 
-def abort(code: int, *args: Any, **kwargs: Any) -> NoReturn:
+def abort(code: int | Response, *args: Any, **kwargs: Any) -> NoReturn:
     """Raise an HTTPException for the given status code."""
     if current_app:
         current_app.aborter(code, *args, **kwargs)


### PR DESCRIPTION
This a small correction to the typing hint for the abort method, it can accept either an int OR a response type, currently the hint only lists an int.