### PR TITLE
Fix a test suite `ImportError` due to a missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ hypothesis = "*"
 mock = "*"
 pytest = "*"
 pytest-asyncio = "*"
+toml = "^0.10.2"
 
 [tool.poetry.scripts]
 quart = "quart.cli:main"

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     pytest-cov
     pytest-sugar
     python-dotenv
+    toml
 commands = pytest --cov=quart {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
This PR introduces `toml` as a test suite dependency (and as a Poetry dev group dependency) to ensure that `test_config.py` can be imported.

Things not addressed in this PR:

* I attempted to add tests for `tomllib` (for Python 3.11 and higher) and `tomli` (for Python 3.10 and lower) as this is the TOML parser included in the Python standard library moving forward. However, it requires the input file to be opened in binary mode so I abandoned this work as out-of-scope.
* mypy 1.4.1 is upset about a protocol/implementation mismatch. I did not dive into this.
* mypy is upset about `readline.set_completer()` in `cli.py` not existing when running on Windows. I attempted to resolve this but found that `cli.py` failed multiple pre-commit hooks, and it would make the overall PR unwieldy.

I recommend running `pre-commit run --all --all-files` on the repo. Also, many pre-commit hooks are very out-of-date. It looks like pre-commit.ci isn't enabled for this repo, and I recommend enabling it. The `ci` configuration in `.pre-commit-config.yaml` may need to be updated as well, or removed.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- Fixes #253

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. (_Tests were already failing_)
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue. (_This work seems too small to add to `CHANGES.rst`_)
- [ ] Add `.. versionchanged::` entries in any relevant code docs. (_Not relevant_)
- [x] Run `pre-commit` hooks and fix any issues. (_Many files in repo already fail pre-commit hook checks, nothing new was introduced in this PR_)
- [x] Run `pytest` and `tox`, no tests failed. (_Test suite is fixed, linters are already failing_)
