### PR TITLE
adds `request.get_data()` and `request.json` to the flask migration examples

### DIFF
--- a/docs/how_to_guides/flask_migration.rst
+++ b/docs/how_to_guides/flask_migration.rst
@@ -68,6 +68,8 @@ function/method is a syntax error.
 .. code-block:: python
 
     await request.data
+    await request.get_data()
+    await request.json
     await request.get_json()
     await request.form
     await request.files


### PR DESCRIPTION
Adds these other common `request` methods to the examples in the migration docs.