### PR TITLE
Fix redefinition of instance_path (#257)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 * Fixed trailing slash issue in URL concatenation for empty 'path'
 * Fixed Issue #219. Use only CR in SSE documentation.
+* Fixed Issue #257. Do not redefine instance_path
 
 0.18.4 2023-04-09
 -----------------

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -291,10 +291,12 @@ class Quart(Scaffold):
         """
         super().__init__(import_name, static_folder, static_url_path, template_folder, root_path)
 
-        instance_path = Path(instance_path) if instance_path else self.auto_find_instance_path()
-        if not instance_path.is_absolute():
+        actual_instance_path = (
+            Path(instance_path) if instance_path else self.auto_find_instance_path()
+        )
+        if not actual_instance_path.is_absolute():
             raise ValueError("The instance_path must be an absolute path.")
-        self.instance_path = instance_path
+        self.instance_path = actual_instance_path
 
         self.aborter = self.make_aborter()
         self.config = self.make_config(instance_relative_config)


### PR DESCRIPTION
Creates a new local called `actual_instance_path` (we can bikeshed on the name 😂). This enables type-checkers that do not like redefined variables to properly infer the type of `Quart.instance_path`.

- fixes #257 
