### PR TITLE
Fix program not closing on Ctrl+C in Windows

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -776,7 +776,8 @@ class Quart(App):
             warnings.warn(
                 f"Additional arguments, {','.join(kwargs.keys())}, are not supported.\n"
                 "They may be supported by Hypercorn, which is the ASGI server Quart "
-                "uses by default. This method is meant for development and debugging."
+                "uses by default. This method is meant for development and debugging.",
+                stacklevel=2,
             )
 
         if loop is None:

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import platform
 import signal
 import sys
 import warnings
@@ -833,8 +832,6 @@ class Quart(App):
         print(f" * Running on {scheme}://{host}:{port} (CTRL + C to quit)")  # noqa: T201
 
         tasks = [loop.create_task(task)]
-        if platform.system() == "Windows":
-            tasks.append(loop.create_task(_windows_signal_support()))
 
         if use_reloader:
             tasks.append(loop.create_task(observe_changes(asyncio.sleep, shutdown_event)))
@@ -1707,11 +1704,3 @@ def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:
                     "task": task,
                 }
             )
-
-
-async def _windows_signal_support() -> None:
-    # See https://bugs.python.org/issue23057, to catch signals on
-    # Windows it is necessary for an IO event to happen periodically.
-    # Fixed by Python 3.8
-    while True:
-        await asyncio.sleep(1)


### PR DESCRIPTION
The _windows_signal_support() loops forever. Using asyncio.gather make that trying to use Ctrl+C to end the program on Windows was just soft-blocking it after closing every other part of the program. The only choice was then to close the terminal window.

_windows_signal_support() was introduced on commit https://github.com/pallets/quart/commit/68da65c9da6f6efe2327c2db2154e88f6297085b to fix an issue on python 3.7. The function was removed since Quart doesn't support 3.7 since 0.19.0.

Closes: https://github.com/pallets/quart/issues/282

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- Add or update relevant docs, in the docs folder and in code : No change in docs
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- Run `pytest` and `tox`, no tests failed : No test failed on tox, get an error with pytest on Windows

Co-authored-by: Julien Castiaux <Julien.castiaux@gmail.com>