### PR TITLE
avoid ResourceWarning in `DataBody.__aiter__` 

### DIFF
--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -98,8 +98,7 @@ class _DataBodyGen(AsyncIterator[bytes]):
             raise StopAsyncIteration
 
         self._iterated = True
-        body = self._data_body
-        return body.data[body.begin : body.end]
+        return self._data_body.body[self._data_body.begin : self._data_body.end]
 
 
 class IterableBody(ResponseBody):

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -64,6 +64,7 @@ def _raise_if_invalid_range(begin: int, end: int, size: int) -> None:
     if begin >= end or abs(begin) > size:
         raise RequestedRangeNotSatisfiable()
 
+
 class DataBody(ResponseBody):
     def __init__(self, data: bytes) -> None:
         self.data = data
@@ -92,7 +93,7 @@ class _DataBodyGen(AsyncIterator[bytes]):
         self._data_body = data_body
         self._iterated = False
 
-    async def __anext__(self):
+    async def __anext__(self) -> bytes:
         if self._iterated:
             raise StopAsyncIteration
 

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -98,7 +98,7 @@ class _DataBodyGen(AsyncIterator[bytes]):
             raise StopAsyncIteration
 
         self._iterated = True
-        return self._data_body.body[self._data_body.begin : self._data_body.end]
+        return self._data_body.data[self._data_body.begin : self._data_body.end]
 
 
 class IterableBody(ResponseBody):


### PR DESCRIPTION
Avoid a ResourceWarning by avoiding an async generator

- fixes #301

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
