### PR TITLE
Fix `DeprecationWarning` from `datetime.utcnow()` use

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.19.5 2024-xx-xx
+-----------------
+
+* Bugfix DeprecationWarnings on Python 3.12
+
 0.19.4 2023-11-19
 -----------------
 

--- a/src/quart/helpers.py
+++ b/src/quart/helpers.py
@@ -4,7 +4,7 @@ import mimetypes
 import os
 import pkgutil
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache, wraps
 from io import BytesIO
 from pathlib import Path
@@ -348,7 +348,7 @@ async def send_file(
     response.cache_control.public = True
     if cache_timeout is not None:
         response.cache_control.max_age = cache_timeout
-        response.expires = datetime.utcnow() + timedelta(seconds=cache_timeout)
+        response.expires = datetime.now(timezone.utc) + timedelta(seconds=cache_timeout)
 
     if add_etags and etag is not None:
         response.set_etag(etag)

--- a/src/quart/sessions.py
+++ b/src/quart/sessions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from flask.sessions import (  # noqa: F401
@@ -75,7 +75,7 @@ class SessionInterface:
         the browser stops accessing the app.
         """
         if session.permanent:
-            return datetime.utcnow() + app.permanent_session_lifetime
+            return datetime.now(timezone.utc) + app.permanent_session_lifetime
         else:
             return None
 


### PR DESCRIPTION
fixes #305

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
