### PR TITLE
Remove obsolete `mock` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ werkzeug = ">=3.0.0"
 
 [tool.poetry.dev-dependencies]
 hypothesis = "*"
-mock = "*"
 pytest = "*"
 pytest-asyncio = "*"
 


### PR DESCRIPTION
Remove the dependency on `mock` package, as the test suite uses only the builtin `unittest.mock` module.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
