### PR TITLE
fix: Use ContentRange in the right way.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,5 @@
+* Fixed Issue #331. Use ContentRange in the right way.
+
 0.19.5 2024-04-01
 -----------------
 

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -414,7 +414,7 @@ class Response(SansIOResponse):
         self.content_range = ContentRange(
             request_range.units,
             self.response.begin,  # type: ignore
-            self.response.end - 1,  # type: ignore
+            self.response.end,  # type: ignore
             complete_length,
         )
         self.status_code = 206

--- a/tests/wrappers/test_response.py
+++ b/tests/wrappers/test_response.py
@@ -97,7 +97,7 @@ async def test_response_make_conditional(http_scope: HTTPScope) -> None:
     assert response.accept_ranges == "bytes"
     assert response.content_range.units == "bytes"
     assert response.content_range.start == 0
-    assert response.content_range.stop == 3
+    assert response.content_range.stop == 4
     assert response.content_range.length == 6
 
 


### PR DESCRIPTION
#### Summary
According to [werkzeug's documentation](https://werkzeug.palletsprojects.com/en/3.0.x/datastructures/#werkzeug.datastructures.ContentRange), end is not included in the range, so end should not be reduced by one. 

#### Changes:
Changed `end - 1` to `end` and modified test at the same time.

#### Issues:
- fixes #331 

#### Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
