### PR TITLE
Update blog tutorial to use pathlib

### DIFF
--- a/docs/tutorials/blog_tutorial.rst
+++ b/docs/tutorials/blog_tutorial.rst
@@ -110,7 +110,7 @@ we can do by adding the command code to *src/blog/__init__.py*:
     from sqlite3 import dbapi2 as sqlite3
 
     app.config.update({
-      "DATABASE": app.root_path / "blog.db",
+      "DATABASE": Path(app.root_path) / "blog.db",
     })
 
     def _connect_db():
@@ -120,7 +120,7 @@ we can do by adding the command code to *src/blog/__init__.py*:
 
     def init_db():
         db = _connect_db()
-        with open(app.root_path / "schema.sql", mode="r") as file_:
+        with open(Path(app.root_path) / "schema.sql", mode="r") as file_:
             db.cursor().executescript(file_.read())
         db.commit()
 


### PR DESCRIPTION
The codeblock imported `pathlib.Path` but it was unused, so the operation for `app.root_path / "blog.db"` would error since `app.root_path` is defined as a string.

- fixes #347 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
