### PR TITLE
Update deployment.rst - uvicorn websockets work

### DIFF
--- a/docs/tutorials/deployment.rst
+++ b/docs/tutorials/deployment.rst
@@ -43,7 +43,7 @@ Server name                                          HTTP/2 HTTP/3 Server Push W
 ==================================================== ====== ====== =========== ==================
 `Hypercorn <https://github.com/pgjones/hypercorn>`_  ✓      ✓      ✓           ✓
 `Daphne <https://github.com/django/daphne>`_         ✓      ✗      ✗           ✗
-`Uvicorn <https://github.com/encode/uvicorn>`_       ✗      ✗      ✗           ✗
+`Uvicorn <https://github.com/encode/uvicorn>`_       ✗      ✗      ✗           ✓
 ==================================================== ====== ====== =========== ==================
 
 Serverless deployment


### PR DESCRIPTION
After trying the example websockets tutorial, uvicorn successfully connected websockets through quart

Edit: additionally I see that daphne claims to support websockets and HTTP2, but I haven't tried it yet.