### PR TITLE
check max_form_memory_size is set before comparing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.19.8
 ------
 
+* Bugfix Fix missing check that caused the previous fix to raise an error. #366
+
 0.19.7 2024-10-25
 -----------------
 

--- a/src/quart/formparser.py
+++ b/src/quart/formparser.py
@@ -190,7 +190,7 @@ class MultiPartParser:
                     container = self.start_file_streaming(event, content_length)
                     _write = container.write
                 elif isinstance(event, Data):
-                    if field_size is not None:
+                    if self.max_form_memory_size is not None and field_size is not None:
                         field_size += len(event.data)
 
                         if field_size > self.max_form_memory_size:


### PR DESCRIPTION
Missed a check that `max_form_memory_size is not None` before comparing it.

fixes #366 