### PR TITLE
Fix a deprecation warning in Python 3.14

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from collections import defaultdict
 from datetime import timedelta
-from inspect import isasyncgen, iscoroutinefunction, isgenerator
+from inspect import isasyncgen, iscoroutinefunction as _inspect_iscoroutinefunction, isgenerator
 from types import TracebackType
 from typing import (
     Any,
@@ -126,6 +126,15 @@ try:
     from typing import ParamSpec
 except ImportError:
     from typing_extensions import ParamSpec  # type: ignore
+
+# Python 3.14 deprecated asyncio.iscoroutinefunction, but suggested
+# inspect.iscoroutinefunction does not work correctly in some Python
+# versions before 3.12.
+# See https://github.com/python/cpython/issues/122858#issuecomment-2466239748
+if sys.version_info >= (3, 12):
+    iscoroutinefunction = _inspect_iscoroutinefunction
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction
 
 AppOrBlueprintKey = Optional[str]  # The App key is None, whereas blueprints are named
 T_after_serving = TypeVar("T_after_serving", bound=AfterServingCallable)

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from collections import defaultdict
 from datetime import timedelta
-from inspect import isasyncgen, isgenerator
+from inspect import isasyncgen, iscoroutinefunction, isgenerator
 from types import TracebackType
 from typing import (
     Any,
@@ -1130,7 +1130,7 @@ class Quart(App):
         run. Before Quart 0.11 this did not run the synchronous code
         in an executor.
         """
-        if asyncio.iscoroutinefunction(func):
+        if iscoroutinefunction(func):
             return func
         else:
             return self.sync_to_async(cast(Callable[P, T], func))


### PR DESCRIPTION
`asyncio.iscoroutinefunction` has been deprecated and emits a warning in Python 3.14: `DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead`