### PR TITLE
Use flask default config for Quartz default config, to pull in missing keys

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,6 @@ jobs:
           - {name: '3.12', python: '3.12', os: ubuntu-latest, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: Typing, python: '3.12', os: ubuntu-latest, tox: mypy}
           - {name: Package, python: '3.12', os: ubuntu-latest, tox: package}
           - {name: Lint, python: '3.12', os: ubuntu-latest, tox: pep8}

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Quart can be installed via `pip
 
     $ pip install quart
 
-and requires Python 3.8.0 or higher (see `python version support
+and requires Python 3.9.0 or higher (see `python version support
 <https://quart.palletsprojects.com/en/latest/discussion/python_versions.html>`_
 for reasoning).
 

--- a/docs/discussion/python_versions.rst
+++ b/docs/discussion/python_versions.rst
@@ -3,8 +3,10 @@
 Python version support
 ======================
 
-The main branch and releases >= 0.19.0 onwards only support Python
-3.8.0 or greater.
+The main branch supports Python 3.9.0 or greater
+
+Releases after 0.6.15, up to 0.19.8 supported Python
+3.8.0 or greater.  Flask 3.1.0 dropped support for Python 3.8 (https://github.com/pallets/flask/releases/tag/3.1.0)
 
 The 0.6-maintenance branch supported Python3.6. The final 0.6.X
 release, 0.6.15, was released in October 2019 after the release of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ aiofiles = "*"
 blinker = ">=1.6"
 click = ">=8.0.0"
 flask = ">=3.0.0"
-hypercorn = ">=0.11.2"
+hypercorn = ">=0.11.2,<=0.16.0"
 importlib_metadata = { version = "*", python = "<3.10" }
 itsdangerous = "*"
 jinja2 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ documentation = "https://quart.palletsprojects.com"
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-aiofiles = "*"
+aiofiles = ">=24.1.0"
 blinker = ">=1.6"
 click = ">=8.0.0"
 flask = ">=3.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -26,7 +25,7 @@ repository = "https://github.com/pallets/quart/"
 documentation = "https://quart.palletsprojects.com"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 aiofiles = "*"
 blinker = ">=1.6"
 click = ">=8.0.0"

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -124,7 +124,7 @@ from .utils import (
 from .wrappers import BaseRequestWebsocket, Request, Response, Websocket
 
 try:
-    from typing import ParamSpec #type: ignore
+    from typing import ParamSpec
 except ImportError:
     from typing_extensions import ParamSpec #type: ignore
 

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -29,6 +29,7 @@ from urllib.parse import quote
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
 from aiofiles.threadpool.binary import AsyncBufferedReader
+import flask.app
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve
@@ -227,6 +228,9 @@ class Quart(App):
     websocket_class = Websocket
 
     default_config = ImmutableDict(
+
+        flask.app.Flask.default_config |
+
         {
             "APPLICATION_ROOT": "/",
             "BACKGROUND_TASK_SHUTDOWN_TIMEOUT": 5,  # Second

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -123,11 +123,10 @@ from .utils import (
 )
 from .wrappers import BaseRequestWebsocket, Request, Response, Websocket
 
-ParamSpec: typing_extensions.ParamSpec | typing.ParamSpec
 try:
-    from typing import ParamSpec
+    from typing import ParamSpec #type: ignore
 except ImportError:
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec #type: ignore
 
 AppOrBlueprintKey = Optional[str]  # The App key is None, whereas blueprints are named
 T_after_serving = TypeVar("T_after_serving", bound=AfterServingCallable)

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -123,6 +123,7 @@ from .utils import (
 )
 from .wrappers import BaseRequestWebsocket, Request, Response, Websocket
 
+ParamSpec: typing_extensions.ParamSpec | typing.ParamSpec
 try:
     from typing import ParamSpec
 except ImportError:

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -126,7 +126,7 @@ from .wrappers import BaseRequestWebsocket, Request, Response, Websocket
 try:
     from typing import ParamSpec
 except ImportError:
-    from typing_extensions import ParamSpec  # type: ignore
+    from typing_extensions import ParamSpec
 
 AppOrBlueprintKey = Optional[str]  # The App key is None, whereas blueprints are named
 T_after_serving = TypeVar("T_after_serving", bound=AfterServingCallable)
@@ -1395,7 +1395,7 @@ class Quart(App):
             response.status_code = int(status)
 
         if headers is not None:
-            response.headers.update(headers)  # type: ignore[arg-type]
+            response.headers.update(headers)
 
         return response
 

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -26,10 +26,10 @@ from typing import (
 )
 from urllib.parse import quote
 
+import flask.app
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
 from aiofiles.threadpool.binary import AsyncBufferedReader
-import flask.app
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve
@@ -228,10 +228,8 @@ class Quart(App):
     websocket_class = Websocket
 
     default_config = ImmutableDict(
-
-        flask.app.Flask.default_config |
-
-        {
+        flask.app.Flask.default_config
+        | {
             "APPLICATION_ROOT": "/",
             "BACKGROUND_TASK_SHUTDOWN_TIMEOUT": 5,  # Second
             "BODY_TIMEOUT": 60,  # Second

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -29,7 +29,6 @@ from urllib.parse import quote
 import flask.app
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
-from aiofiles.threadpool.binary import AsyncBufferedReader
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve
@@ -126,7 +125,7 @@ from .wrappers import BaseRequestWebsocket, Request, Response, Websocket
 try:
     from typing import ParamSpec
 except ImportError:
-    from typing_extensions import ParamSpec #type: ignore
+    from typing_extensions import ParamSpec  # type: ignore
 
 AppOrBlueprintKey = Optional[str]  # The App key is None, whereas blueprints are named
 T_after_serving = TypeVar("T_after_serving", bound=AfterServingCallable)

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -377,7 +377,7 @@ class Quart(App):
         self,
         path: FilePath,
         mode: str = "rb",
-    ) -> AiofilesContextManager[None, None, AsyncBufferedReader]:
+    ) -> AiofilesContextManager:
         """Open a file for reading.
 
         Use as
@@ -394,7 +394,7 @@ class Quart(App):
 
     async def open_instance_resource(
         self, path: FilePath, mode: str = "rb"
-    ) -> AiofilesContextManager[None, None, AsyncBufferedReader]:
+    ) -> AiofilesContextManager:
         """Open a file for reading.
 
         Use as

--- a/src/quart/blueprints.py
+++ b/src/quart/blueprints.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
-from aiofiles.threadpool.binary import AsyncBufferedReader
 from flask.sansio.app import App
 from flask.sansio.blueprints import (  # noqa
     Blueprint as SansioBlueprint,

--- a/src/quart/blueprints.py
+++ b/src/quart/blueprints.py
@@ -101,7 +101,7 @@ class Blueprint(SansioBlueprint):
         self,
         path: FilePath,
         mode: str = "rb",
-    ) -> AiofilesContextManager[None, None, AsyncBufferedReader]:
+    ) -> AiofilesContextManager:
         """Open a file for reading.
 
         Use as

--- a/src/quart/ctx.py
+++ b/src/quart/ctx.py
@@ -130,7 +130,7 @@ class RequestContext(_BaseRequestWebsocketContext):
         session: SessionMixin | None = None,
     ) -> None:
         super().__init__(app, request, session)
-        self.flashes = None
+        self.flashes: Any | list[Any] | None = None
         self._after_request_functions: list[AfterRequestCallable] = []
 
     @property

--- a/src/quart/wrappers/request.py
+++ b/src/quart/wrappers/request.py
@@ -187,35 +187,32 @@ class Request(BaseRequestWebsocket):
         return await self.get_data(as_text=False, parse_form_data=True)
 
     @overload
-    async def get_data(
-        self, as_text: Literal[False], parse_form_data: bool) -> bytes: ...
+    async def get_data(self, as_text: Literal[False], parse_form_data: bool) -> bytes: ...
 
     @overload
     async def get_data(self, as_text: Literal[True], parse_form_data: bool) -> str: ...
 
     @overload
     async def get_data(
-        self, cache: bool, as_text: Literal[False], parse_form_data: bool) -> bytes: ...
+        self, cache: bool, as_text: Literal[False], parse_form_data: bool
+    ) -> bytes: ...
 
     @overload
     async def get_data(self, cache: bool, as_text: Literal[True], parse_form_data: bool) -> str: ...
 
     @overload
-    async def get_data(
-        self, cache: bool, as_text: Literal[False]) -> bytes: ...
+    async def get_data(self, cache: bool, as_text: Literal[False]) -> bytes: ...
 
     @overload
     async def get_data(self, cache: bool, as_text: Literal[True]) -> str: ...
 
     @overload
-    async def get_data(
-        self, cache: bool
-    ) -> bytes: ...
+    async def get_data(self, cache: bool) -> bytes: ...
 
     @overload
     async def get_data(self) -> bytes: ...
 
-    async def get_data( #type: ignore[misc]
+    async def get_data(  # type: ignore[misc]
         self, cache: bool = True, as_text: bool = False, parse_form_data: bool = False
     ) -> str | bytes:
         """Get the request body data.

--- a/src/quart/wrappers/request.py
+++ b/src/quart/wrappers/request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AnyStr, Awaitable, Callable, Generator, NoReturn, overload
+from typing import Any, Awaitable, Callable, Generator, NoReturn, overload
 
 from hypercorn.typing import HTTPScope
 from werkzeug.datastructures import CombinedMultiDict, Headers, iter_multi_items, MultiDict
@@ -188,25 +188,41 @@ class Request(BaseRequestWebsocket):
 
     @overload
     async def get_data(
-        self, cache: bool, as_text: Literal[False], parse_form_data: bool
-    ) -> bytes: ...
+        self, as_text: Literal[False], parse_form_data: bool) -> bytes: ...
+
+    @overload
+    async def get_data(self, as_text: Literal[True], parse_form_data: bool) -> str: ...
+
+    @overload
+    async def get_data(
+        self, cache: bool, as_text: Literal[False], parse_form_data: bool) -> bytes: ...
 
     @overload
     async def get_data(self, cache: bool, as_text: Literal[True], parse_form_data: bool) -> str: ...
 
     @overload
     async def get_data(
-        self, cache: bool = True, as_text: bool = False, parse_form_data: bool = False
-    ) -> AnyStr: ...
+        self, cache: bool, as_text: Literal[False]) -> bytes: ...
 
+    @overload
+    async def get_data(self, cache: bool, as_text: Literal[True]) -> str: ...
+
+    @overload
     async def get_data(
+        self, cache: bool
+    ) -> bytes: ...
+
+    @overload
+    async def get_data(self) -> bytes: ...
+
+    async def get_data( #type: ignore[misc]
         self, cache: bool = True, as_text: bool = False, parse_form_data: bool = False
-    ) -> AnyStr:
+    ) -> str | bytes:
         """Get the request body data.
 
         Arguments:
             cache: If False the body data will be cleared, resulting in any
-                subsequent calls returning an empty AnyStr and reducing
+                subsequent calls returning '' or b'' and reducing
                 memory usage.
             as_text: If True the data is returned as a decoded string,
                 otherwise raw bytes are returned.

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -148,7 +148,7 @@ class FileBody(ResponseBody):
         if buffer_size is not None:
             self.buffer_size = buffer_size
         self.file: AsyncBufferedIOBase | None = None
-        self.file_manager: AiofilesContextManager[None, None, AsyncBufferedReader] = None
+        self.file_manager: AiofilesContextManager = None
 
     async def __aenter__(self) -> FileBody:
         self.file_manager = async_open(self.file_path, mode="rb")
@@ -296,7 +296,7 @@ class Response(SansIOResponse):
         elif isinstance(response, ResponseBody):
             self.response = response
         elif isinstance(response, (str, bytes)):
-            self.set_data(response)  # type: ignore
+            self.set_data(response) 
         else:
             self.response = self.iterable_body_class(response)
 
@@ -314,9 +314,9 @@ class Response(SansIOResponse):
     async def get_data(self, as_text: Literal[False]) -> bytes: ...
 
     @overload
-    async def get_data(self, as_text: bool = True) -> AnyStr: ...
+    async def get_data(self) -> bytes: ...
 
-    async def get_data(self, as_text: bool = False) -> AnyStr:
+    async def get_data(self, as_text: bool = False) -> str | bytes:
         """Return the body data."""
         if self.implicit_sequence_conversion:
             await self.make_sequence()
@@ -327,9 +327,9 @@ class Response(SansIOResponse):
                     result += data.decode()
                 else:
                     result += data
-        return result  # type: ignore
+        return result
 
-    def set_data(self, data: AnyStr) -> None:
+    def set_data(self, data: str | bytes) -> None:
         """Set the response data.
 
         This will encode using the :attr:`charset`.
@@ -366,7 +366,7 @@ class Response(SansIOResponse):
         if not (force or self.is_json):
             return None
 
-        data = await self.get_data(as_text=True)
+        data: str = await self.get_data(as_text=True)
         try:
             return self.json_module.loads(data)
         except ValueError:

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -296,7 +296,7 @@ class Response(SansIOResponse):
         elif isinstance(response, ResponseBody):
             self.response = response
         elif isinstance(response, (str, bytes)):
-            self.set_data(response) 
+            self.set_data(response)
         else:
             self.response = self.iterable_body_class(response)
 

--- a/src/quart/wrappers/response.py
+++ b/src/quart/wrappers/response.py
@@ -19,7 +19,7 @@ from typing import (
 
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
-from aiofiles.threadpool.binary import AsyncBufferedIOBase, AsyncBufferedReader
+from aiofiles.threadpool.binary import AsyncBufferedIOBase
 from werkzeug.datastructures import ContentRange, Headers
 from werkzeug.exceptions import RequestedRangeNotSatisfiable
 from werkzeug.http import parse_etags

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -83,13 +83,13 @@ async def test_index(path: str, app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get(path)
     assert response.status_code == 200
-    assert b"index" in (await response.get_data())  # type: ignore
+    assert b"index" in (await response.get_data())
 
 
 async def test_iri(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/❤️")
-    assert "💔".encode() in (await response.get_data())  # type: ignore
+    assert "💔".encode() in (await response.get_data())
 
 
 async def test_options(app: Quart) -> None:
@@ -107,35 +107,35 @@ async def test_json(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.post("/json/", json={"value": "json"})
     assert response.status_code == 200
-    assert b'{"value":"json"}\n' == (await response.get_data())  # type: ignore
+    assert b'{"value":"json"}\n' == (await response.get_data())
 
 
 async def test_implicit_json(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.post("/implicit_json/", json={"value": "json"})
     assert response.status_code == 200
-    assert b'{"value":"json"}\n' == (await response.get_data())  # type: ignore
+    assert b'{"value":"json"}\n' == (await response.get_data())
 
 
 async def test_implicit_json_list(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.post("/implicit_json/", json=["a", 2])
     assert response.status_code == 200
-    assert b'["a",2]\n' == (await response.get_data())  # type: ignore
+    assert b'["a",2]\n' == (await response.get_data())
 
 
 async def test_werkzeug(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/werkzeug/")
     assert response.status_code == 200
-    assert b"Hello" == (await response.get_data())  # type: ignore
+    assert b"Hello" == (await response.get_data())
 
 
 async def test_generic_error(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/error/")
     assert response.status_code == 409
-    assert b"Something Unique" in (await response.get_data())  # type: ignore
+    assert b"Something Unique" in (await response.get_data())
 
 
 async def test_url_defaults(app: Quart) -> None:
@@ -151,7 +151,7 @@ async def test_not_found_error(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/not_found/")
     assert response.status_code == 404
-    assert b"Not Found" in (await response.get_data())  # type: ignore
+    assert b"Not Found" in (await response.get_data())
 
 
 async def test_make_response_str(app: Quart) -> None:
@@ -225,4 +225,4 @@ async def test_root_path(app: Quart) -> None:
 async def test_stream(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/stream")
-    assert (await response.get_data()) == b"Hello World"  # type: ignore
+    assert (await response.get_data()) == b"Hello World"

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -86,7 +86,7 @@ async def test_empty_path_with_url_prefix() -> None:
     test_client = app.test_client()
     response = await test_client.get("/prefix")
     assert response.status_code == 200
-    assert await response.get_data() == b"OK"  # type: ignore
+    assert await response.get_data() == b"OK"
 
 
 async def test_blueprint_template_filter() -> None:
@@ -104,7 +104,7 @@ async def test_blueprint_template_filter() -> None:
     app.register_blueprint(blueprint)
 
     response = await app.test_client().get("/")
-    assert b"olleh" in (await response.get_data())  # type: ignore
+    assert b"olleh" in (await response.get_data())
 
 
 async def test_blueprint_error_handler() -> None:
@@ -124,7 +124,7 @@ async def test_blueprint_error_handler() -> None:
 
     response = await app.test_client().get("/error/")
     assert response.status_code == 409
-    assert b"Something Unique" in (await response.get_data())  # type: ignore
+    assert b"Something Unique" in (await response.get_data())
 
 
 async def test_blueprint_method_view() -> None:
@@ -328,14 +328,14 @@ async def test_nested_blueprint() -> None:
 
     client = app.test_client()
 
-    assert (await (await client.get("/parent/")).get_data()) == b"Parent yes"  # type: ignore
-    assert (await (await client.get("/parent/child/")).get_data()) == b"Child yes"  # type: ignore
-    assert (await (await client.get("/parent/sibling")).get_data()) == b"Sibling yes"  # type: ignore  # noqa: E501
-    assert (await (await client.get("/alt/sibling")).get_data()) == b"Sibling yes"  # type: ignore
-    assert (await (await client.get("/parent/child/grandchild/")).get_data()) == b"Grandchild yes"  # type: ignore  # noqa: E501
-    assert (await (await client.get("/parent/no")).get_data()) == b"Parent no"  # type: ignore
-    assert (await (await client.get("/parent/child/no")).get_data()) == b"Parent no"  # type: ignore
-    assert (await (await client.get("/parent/child/grandchild/no")).get_data()) == b"Grandchild no"  # type: ignore  # noqa: E501
+    assert (await (await client.get("/parent/")).get_data()) == b"Parent yes"
+    assert (await (await client.get("/parent/child/")).get_data()) == b"Child yes"
+    assert (await (await client.get("/parent/sibling")).get_data()) == b"Sibling yes"  # noqa: E501
+    assert (await (await client.get("/alt/sibling")).get_data()) == b"Sibling yes"
+    assert (await (await client.get("/parent/child/grandchild/")).get_data()) == b"Grandchild yes"  # noqa: E501
+    assert (await (await client.get("/parent/no")).get_data()) == b"Parent no"
+    assert (await (await client.get("/parent/child/no")).get_data()) == b"Parent no"
+    assert (await (await client.get("/parent/child/grandchild/no")).get_data()) == b"Grandchild no"  # noqa: E501
 
 
 async def test_blueprint_renaming() -> None:
@@ -366,12 +366,12 @@ async def test_blueprint_renaming() -> None:
 
     client = app.test_client()
 
-    assert (await (await client.get("/a/")).get_data()) == b"bp.index"  # type: ignore
-    assert (await (await client.get("/b/")).get_data()) == b"alt.index"  # type: ignore
-    assert (await (await client.get("/a/a/")).get_data()) == b"bp.sub.index2"  # type: ignore
-    assert (await (await client.get("/b/a/")).get_data()) == b"alt.sub.index2"  # type: ignore
-    assert (await (await client.get("/a/error")).get_data()) == b"Error"  # type: ignore
-    assert (await (await client.get("/b/error")).get_data()) == b"Error"  # type: ignore
+    assert (await (await client.get("/a/")).get_data()) == b"bp.index"
+    assert (await (await client.get("/b/")).get_data()) == b"alt.index"
+    assert (await (await client.get("/a/a/")).get_data()) == b"bp.sub.index2"
+    assert (await (await client.get("/b/a/")).get_data()) == b"alt.sub.index2"
+    assert (await (await client.get("/a/error")).get_data()) == b"Error"
+    assert (await (await client.get("/b/error")).get_data()) == b"Error"
 
 
 def test_self_registration() -> None:
@@ -461,5 +461,5 @@ async def test_nested_callback_order() -> None:
     client = app.test_client()
     assert (
         await (await client.get("/a")).get_data()
-    ) == b"app_1, app_2, parent_1, parent_2, child_1, child_2"  # type: ignore
-    assert (await (await client.get("/b")).get_data()) == b"child"  # type: ignore
+    ) == b"app_1, app_2, parent_1, parent_2, child_1, child_2"
+    assert (await (await client.get("/b")).get_data()) == b"child"

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -332,10 +332,14 @@ async def test_nested_blueprint() -> None:
     assert (await (await client.get("/parent/child/")).get_data()) == b"Child yes"
     assert (await (await client.get("/parent/sibling")).get_data()) == b"Sibling yes"  # noqa: E501
     assert (await (await client.get("/alt/sibling")).get_data()) == b"Sibling yes"
-    assert (await (await client.get("/parent/child/grandchild/")).get_data()) == b"Grandchild yes"  # noqa: E501
+    assert (
+        await (await client.get("/parent/child/grandchild/")).get_data()
+    ) == b"Grandchild yes"  # noqa: E501
     assert (await (await client.get("/parent/no")).get_data()) == b"Parent no"
     assert (await (await client.get("/parent/child/no")).get_data()) == b"Parent no"
-    assert (await (await client.get("/parent/child/grandchild/no")).get_data()) == b"Grandchild no"  # noqa: E501
+    assert (
+        await (await client.get("/parent/child/grandchild/no")).get_data()
+    ) == b"Grandchild no"  # noqa: E501
 
 
 async def test_blueprint_renaming() -> None:

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -10,4 +10,4 @@ async def test_debug() -> None:
         response = await traceback_response(Exception("Unique error"))
 
     assert response.status_code == 500
-    assert b"Unique error" in (await response.get_data())  # type: ignore
+    assert b"Unique error" in (await response.get_data())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -31,14 +31,14 @@ def _app() -> Quart:
 async def test_sync_request_context(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/")
-    assert b"GET" in (await response.get_data())  # type: ignore
+    assert b"GET" in (await response.get_data())
     response = await test_client.post("/")
-    assert b"POST" in (await response.get_data())  # type: ignore
+    assert b"POST" in (await response.get_data())
 
 
 async def test_sync_generator(app: Quart) -> None:
     test_client = app.test_client()
     response = await test_client.get("/gen")
     result = await response.get_data()
-    assert result[-2:] == b"bb"  # type: ignore
+    assert result[-2:] == b"bb"
     assert int(result[:-2]) != threading.current_thread().ident

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -232,7 +232,7 @@ async def test_data() -> None:
     app = Quart(__name__)
 
     @app.route("/", methods=["POST"])
-    async def echo() -> str:
+    async def echo() -> bytes:
         data = await request.get_data(True)
         return data
 
@@ -365,7 +365,7 @@ async def test_session_transactions() -> None:
         local_session["foo"] = [42]
         assert len(local_session) == 1
     response = await test_client.get("/")
-    assert (await response.get_data()) == b"[42]"  # type: ignore
+    assert (await response.get_data()) == b"[42]"
     async with test_client.session_transaction() as local_session:
         assert len(local_session) == 1
         assert local_session["foo"] == [42]

--- a/tests/wrappers/test_response.py
+++ b/tests/wrappers/test_response.py
@@ -73,9 +73,9 @@ def test_response_status(status: Any, expected: int) -> None:
 
 async def test_response_body() -> None:
     response = Response(b"Body")
-    assert b"Body" == (await response.get_data())  # type: ignore
+    assert b"Body" == (await response.get_data())
     # Fetch again to ensure it isn't exhausted
-    assert b"Body" == (await response.get_data())  # type: ignore
+    assert b"Body" == (await response.get_data())
 
 
 async def test_response_make_conditional(http_scope: HTTPScope) -> None:
@@ -92,7 +92,7 @@ async def test_response_make_conditional(http_scope: HTTPScope) -> None:
     )
     response = Response(b"abcdef")
     await response.make_conditional(request, accept_ranges=True, complete_length=6)
-    assert b"abcd" == (await response.get_data())  # type: ignore
+    assert b"abcd" == (await response.get_data())
     assert response.status_code == 206
     assert response.accept_ranges == "bytes"
     assert response.content_range.units == "bytes"
@@ -107,7 +107,7 @@ async def test_response_make_conditional_no_condition(http_scope: HTTPScope) -> 
     )
     response = Response(b"abcdef")
     await response.make_conditional(request, complete_length=6)
-    assert b"abcdef" == (await response.get_data())  # type: ignore
+    assert b"abcdef" == (await response.get_data())
     assert response.status_code == 200
 
 
@@ -125,7 +125,7 @@ async def test_response_make_conditional_out_of_bound(http_scope: HTTPScope) -> 
     )
     response = Response(b"abcdef")
     await response.make_conditional(request, complete_length=6)
-    assert b"abcdef" == (await response.get_data())  # type: ignore
+    assert b"abcdef" == (await response.get_data())
     assert response.status_code == 206
 
 
@@ -145,7 +145,7 @@ async def test_response_make_conditional_not_modified(http_scope: HTTPScope) -> 
     )
     await response.make_conditional(request)
     assert response.status_code == 304
-    assert b"" == (await response.get_data())  # type: ignore
+    assert b"" == (await response.get_data())
     assert "content-length" not in response.headers
 
 
@@ -182,7 +182,7 @@ def test_response_cache_control() -> None:
 
 async def test_empty_response() -> None:
     response = Response()
-    assert b"" == (await response.get_data())  # type: ignore
+    assert b"" == (await response.get_data())
 
 
 @given(


### PR DESCRIPTION

- fixes  #371
- drops Python 3.8 (this is needed anyway, but I wanted to use Python 3.9's `|` operator to combine dictionaries)
