### PR TITLE
Base Quart's default_config on Flask's

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -28,6 +28,7 @@ from urllib.parse import quote
 
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
+import flask.app
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve
@@ -235,7 +236,8 @@ class Quart(App):
     websocket_class = Websocket
 
     default_config = ImmutableDict(
-        {
+        flask.app.Flask.default_config
+        | {
             "APPLICATION_ROOT": "/",
             "BACKGROUND_TASK_SHUTDOWN_TIMEOUT": 5,  # Second
             "BODY_TIMEOUT": 60,  # Second

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -26,7 +26,7 @@ from typing import (
 )
 from urllib.parse import quote
 
-import flask.app
+from flask.app import Flask
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
 from flask.sansio.app import App
@@ -236,7 +236,7 @@ class Quart(App):
     websocket_class = Websocket
 
     default_config = ImmutableDict(
-        flask.app.Flask.default_config
+        Flask.default_config
         | {
             "APPLICATION_ROOT": "/",
             "BACKGROUND_TASK_SHUTDOWN_TIMEOUT": 5,  # Second

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -26,9 +26,9 @@ from typing import (
 )
 from urllib.parse import quote
 
+import flask.app
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
-import flask.app
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -26,9 +26,9 @@ from typing import (
 )
 from urllib.parse import quote
 
-from flask.app import Flask
 from aiofiles import open as async_open
 from aiofiles.base import AiofilesContextManager
+from flask.app import Flask
 from flask.sansio.app import App
 from flask.sansio.scaffold import setupmethod
 from hypercorn.asyncio import serve


### PR DESCRIPTION
Fixes #371 without pinning Flask to 3.0.0


- [x ] Run `pre-commit` hooks and fix any issues.

A three line change, as per the title:

![image](https://github.com/user-attachments/assets/79e065d2-97b5-4049-9c6f-cc87426deb9e)
