### PR TITLE
Fix propagating exceptions

### DIFF
--- a/src/quart/asgi.py
+++ b/src/quart/asgi.py
@@ -351,7 +351,7 @@ def _convert_version(raw: str) -> list[int]:
 
 
 async def _handle_exception(app: Quart, error: Exception) -> Response:
-    if not app.testing and app.config["PROPAGATE_EXCEPTIONS"]:
+    if not app.testing and not app.config["PROPAGATE_EXCEPTIONS"]:
         return await traceback_response(error)
     else:
         raise error

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -319,10 +319,10 @@ def test_http_asgi_scope_from_request() -> None:
 @pytest.mark.parametrize(
     "propagate_exceptions, testing, raises",
     [
-        (True, False, False),
+        (True, False, True),
         (True, True, True),
         (False, True, True),
-        (False, False, True),
+        (False, False, False),
     ],
 )
 async def test__handle_exception(propagate_exceptions: bool, testing: bool, raises: bool) -> None:


### PR DESCRIPTION
Fixes propagating exceptions when the `PROPAGATE_EXCEPTIONS` config setting is set to `True` by fixing exception handling in `ASGIHTTPConnection`. Currently, when `PROPAGATE_EXCEPTIONS` is set to `True` it returns the traceback as HTML instead of propagating the exception.

- fixes #383
