### PR TITLE
Fix `app.blueprints` type annotation

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -48,6 +48,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 from .asgi import ASGIHTTPConnection
 from .asgi import ASGILifespan
 from .asgi import ASGIWebsocketConnection
+from .blueprints import Blueprint
 from .cli import AppGroup
 from .config import Config
 from .ctx import _AppCtxGlobals
@@ -224,6 +225,7 @@ class Quart(App):
     asgi_http_class = ASGIHTTPConnection
     asgi_lifespan_class = ASGILifespan
     asgi_websocket_class = ASGIWebsocketConnection
+    blueprints: dict[str, Blueprint]  # type: ignore[assignment]
     config_class = Config
     event_class = asyncio.Event
     jinja_environment = Environment  # type: ignore[assignment]


### PR DESCRIPTION
Add `quart.blueprints.Blueprint` type annotation for the `blueprints` property instead of the inherited `flask.sansio.blueprints.Blueprint` type.

fixes #404 

With a given MRE:
```python
from quart import Quart
from quart.blueprints import Blueprint


app = Quart(__name__)
bp = Blueprint("test", __name__)
app.register_blueprint(bp)

# This works at runtime but fails type check
def process_blueprint(blueprint: Blueprint) -> None:
    print(f"Processing blueprint: {blueprint.name}")

# Type error here - blueprints.values() returns flask.sansio.blueprints.Blueprint
for blueprint in app.blueprints.values():
    process_blueprint(blueprint)  # Error: Expected quart.blueprints.Blueprint, got flask.sansio.blueprints.Blueprint

# Show inferred types
reveal_type(bp)  # Shows quart.blueprints.Blueprint
reveal_type(app.blueprints)  # Now it shows Dict[str,quart.blueprints.Blueprint] instead of Dict[str, flask.sansio.blueprints.Blueprint]

```