### PR TITLE
doc: Fix example code in documentation of app.add_websocket

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -645,7 +645,7 @@ class Quart(App):
             def websocket_route():
                 ...
 
-            app.add_websocket('/', websocket_route)
+            app.add_websocket('/', view_func=websocket_route)
 
         Arguments:
             rule: The path to route on, should start with a ``/``.


### PR DESCRIPTION
The current example code in the documentation assigns a function to the `endpoint: str | None` argument of add_websocket.
Example code from docs:
```python
def websocket_route():
    ...

app.add_websocket('/', websocket_route)
```
Function signature:
```python
add_websocket(rule, endpoint=None, view_func=None, **options)
```
This does not work. I believe the intended way is to assign the function to the `view_func` parameter and change the corresponding doc entry with this pull request.
