### PR TITLE
Implement backpressure for HTTP request body and WebSocket messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "itsdangerous",
     "jinja2",
     "markupsafe",
-    "typing-extensions; python_version < '3.10'",
+    "typing-extensions; python_version < '3.11'",
     "werkzeug>=3.0",
 ]
 

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -84,6 +84,7 @@ from .signals import websocket_started
 from .signals import websocket_tearing_down
 from .templating import _default_template_ctx_processor
 from .templating import Environment
+from .testing import make_test_body_chunks
 from .testing import make_test_body_with_headers
 from .testing import make_test_headers_path_and_query_string
 from .testing import make_test_scope
@@ -1363,10 +1364,10 @@ class Quart(App):
             headers,
             root_path,
             http_version,
+            body_chunks=make_test_body_chunks(request_body),
             send_push_promise=send_push_promise,
             scope=scope,
         )
-        request.body.set_result(request_body)
         return self.request_context(request)
 
     def add_background_task(self, func: Callable, *args: Any, **kwargs: Any) -> None:

--- a/src/quart/asgi.py
+++ b/src/quart/asgi.py
@@ -183,7 +183,7 @@ class ASGIWebsocketConnection:
     def __init__(self, app: Quart, scope: WebsocketScope) -> None:
         self.app = app
         self.scope = scope
-        self.queue: asyncio.Queue = asyncio.Queue()
+        self.queue: asyncio.Queue = asyncio.Queue(1)
         self._accepted = False
         self._closed = False
 

--- a/src/quart/asgi.py
+++ b/src/quart/asgi.py
@@ -31,6 +31,7 @@ from .debug import traceback_response
 from .signals import websocket_received
 from .signals import websocket_sent
 from .typing import ResponseTypes
+from .utils import AsyncQueueIterator
 from .utils import cancel_tasks
 from .utils import encode_headers
 from .utils import raise_task_exceptions
@@ -46,12 +47,13 @@ class ASGIHTTPConnection:
     def __init__(self, app: Quart, scope: HTTPScope) -> None:
         self.app = app
         self.scope = scope
+        self.queue: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
 
     async def __call__(
         self, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
         request = self._create_request_from_scope(send)
-        receiver_task = asyncio.ensure_future(self.handle_messages(request, receive))
+        receiver_task = asyncio.ensure_future(self.handle_messages(receive))
         handler_task = asyncio.ensure_future(self.handle_request(request, send))
         done, pending = await asyncio.wait(
             [handler_task, receiver_task], return_when=asyncio.FIRST_COMPLETED
@@ -59,15 +61,15 @@ class ASGIHTTPConnection:
         await cancel_tasks(pending)
         raise_task_exceptions(done)
 
-    async def handle_messages(
-        self, request: Request, receive: ASGIReceiveCallable
-    ) -> None:
+    async def handle_messages(self, receive: ASGIReceiveCallable) -> None:
+        queue = self.queue  # for quicker access in the loop
+
         while True:
             message = await receive()
             if message["type"] == "http.request":
-                request.body.append(message.get("body", b""))
+                await queue.put(message.get("body", b""))
                 if not message.get("more_body", False):
-                    request.body.set_complete()
+                    queue.set_complete()
             elif message["type"] == "http.disconnect":
                 return
 
@@ -99,6 +101,7 @@ class ASGIHTTPConnection:
             self.scope["http_version"],
             max_content_length=self.app.config["MAX_CONTENT_LENGTH"],
             body_timeout=self.app.config["BODY_TIMEOUT"],
+            body_chunks=self.queue,
             send_push_promise=partial(self._send_push_promise, send),
             scope=self.scope,
         )

--- a/src/quart/testing/__init__.py
+++ b/src/quart/testing/__init__.py
@@ -9,6 +9,7 @@ from ..cli import ScriptInfo
 from .app import TestApp
 from .client import QuartClient
 from .connections import WebsocketResponseError
+from .utils import make_test_body_chunks
 from .utils import make_test_body_with_headers
 from .utils import make_test_headers_path_and_query_string
 from .utils import make_test_scope
@@ -35,6 +36,7 @@ class QuartCliRunner(CliRunner):
 
 
 __all__ = (
+    "make_test_body_chunks",
     "make_test_body_with_headers",
     "make_test_headers_path_and_query_string",
     "make_test_scope",

--- a/src/quart/testing/utils.py
+++ b/src/quart/testing/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 from typing import AnyStr
 from typing import cast
@@ -216,6 +217,11 @@ def make_test_scope(
     elif type_ == "websocket":
         scope["extensions"] = {"websocket.http.response": {}}
     return cast(Scope, scope)
+
+
+async def make_test_body_chunks(*chunks: bytes) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
 
 
 async def no_op_push(path: str, headers: Headers) -> None:

--- a/src/quart/utils.py
+++ b/src/quart/utils.py
@@ -24,7 +24,7 @@ from werkzeug.datastructures import Headers
 from .typing import Event
 from .typing import FilePath
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self

--- a/src/quart/utils.py
+++ b/src/quart/utils.py
@@ -24,6 +24,11 @@ from werkzeug.datastructures import Headers
 from .typing import Event
 from .typing import FilePath
 
+if sys.version_info >= (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 if TYPE_CHECKING:
     from .wrappers.response import Response  # noqa: F401
 
@@ -184,3 +189,61 @@ def raise_task_exceptions(tasks: set[asyncio.Task]) -> None:
     for task in tasks:
         if not task.cancelled() and task.exception() is not None:
             raise task.exception()
+
+
+# Dummy type used in AsyncQueueIterator to wakeup an await without sending any
+# data.  (None isn't used for that, because the generic type T could allow None
+# as valid data in the queue.)
+class _AsyncQueueWakeup:
+    pass
+
+
+# Items go in using an async queue interface, and come out via async iteration.
+class AsyncQueueIterator(AsyncIterator[T]):
+    _queue: asyncio.Queue[T | _AsyncQueueWakeup]
+    _complete: bool
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self._queue = asyncio.Queue(maxsize)
+        self._complete = False  # In Python 3.13, use queue's shutdown() instead
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> T:
+        while not (self._queue.empty() and self._complete):
+            item = await self._queue.get()
+
+            if not isinstance(item, _AsyncQueueWakeup):
+                return item
+
+        raise StopAsyncIteration()
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def full(self) -> bool:
+        return self._queue.full()
+
+    def complete(self) -> bool:
+        return self._complete
+
+    def _reject_if_complete(self) -> None:
+        if self._complete:
+            raise RuntimeError("already complete")
+
+    async def put(self, item: T) -> None:
+        self._reject_if_complete()
+
+        await self._queue.put(item)
+
+    def put_nowait(self, item: T) -> None:
+        self._reject_if_complete()
+
+        self._queue.put_nowait(item)
+
+    def set_complete(self) -> None:
+        self._complete = True
+
+        if self._queue.empty():  # so a get() might be waiting
+            self._queue.put_nowait(_AsyncQueueWakeup())

--- a/src/quart/wrappers/request.py
+++ b/src/quart/wrappers/request.py
@@ -171,8 +171,6 @@ class Request(BaseRequestWebsocket):
             root_path: The root path that should be prepended to all
                 routes.
             http_version: The HTTP version of the request.
-            body: An awaitable future for the body data i.e.
-                ``data = await body``
             max_content_length: The maximum length in bytes of the
                 body (None implies no limit in Quart).
             body_timeout: The maximum time (seconds) to wait for the

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,7 @@ from quart.globals import session
 from quart.globals import websocket
 from quart.sessions import SecureCookieSession
 from quart.sessions import SessionInterface
+from quart.testing import make_test_body_chunks
 from quart.testing import no_op_push
 from quart.testing import WebsocketResponseError
 from quart.typing import ResponseReturnValue
@@ -273,6 +274,7 @@ async def test_app_handle_request_asyncio_cancelled_error(
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     with pytest.raises(asyncio.CancelledError):
@@ -390,6 +392,7 @@ async def test_propagation(
                     "",
                     "1.1",
                     http_scope,
+                    body_chunks=make_test_body_chunks(),
                     send_push_promise=no_op_push,
                 )
             )

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -118,7 +118,7 @@ async def test_http_request_without_body(request_message: dict) -> None:
 
     # This test fails with a timeout error if the request body is not received
     # within 1 second
-    receiver_task = asyncio.ensure_future(connection.handle_messages(request, receive))
+    receiver_task = asyncio.ensure_future(connection.handle_messages(receive))
     body = await asyncio.wait_for(request.body, timeout=1)
     receiver_task.cancel()
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -12,6 +12,7 @@ from hypercorn.typing import WebsocketScope
 from werkzeug.datastructures import Headers
 
 from quart import Quart
+from quart import websocket
 from quart.asgi import _convert_version
 from quart.asgi import _handle_exception
 from quart.asgi import ASGIHTTPConnection
@@ -158,6 +159,61 @@ async def test_websocket_completion() -> None:
 
     # This test fails if a timeout error is raised here
     await asyncio.wait_for(connection(receive, send), timeout=1)
+
+
+async def test_websocket_backpressure() -> None:
+    app = Quart(__name__)
+    scope: WebsocketScope = {
+        "type": "websocket",
+        "asgi": {},
+        "http_version": "1.1",
+        "scheme": "wss",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"quart")],
+        "client": ("127.0.0.1", 80),
+        "server": None,
+        "subprotocols": [],
+        "extensions": {"websocket.http.response": {}},
+        "state": {},  # type: ignore[typeddict-item]
+    }
+    connection = ASGIWebsocketConnection(app, scope)
+
+    count = 3
+
+    queue: asyncio.Queue = asyncio.Queue()
+    queue.put_nowait({"type": "websocket.connect"})
+    for i in range(count):
+        queue.put_nowait({"type": "websocket.receive", "text": str(i)})
+    queue.put_nowait({"type": "websocket.disconnect"})
+
+    async def receive() -> ASGIReceiveEvent:
+        return await queue.get()
+
+    async def send(message: ASGISendEvent) -> None:
+        pass
+
+    size_checks: list[tuple[int, int]] = []
+
+    @app.websocket("/")
+    async def ws() -> None:
+        while True:
+            n = int(await websocket.receive())
+
+            size_check = (n, queue.qsize())
+            size_checks.append(size_check)
+
+    await connection(receive, send)
+
+    assert len(size_checks) == count
+    for n, qsize in size_checks:
+        # At each step, the queue contains the remaining data messages except
+        # for the one that's just been received and the next one after it (that
+        # one's been moved to the connection's internal queue), plus the
+        # disconnect message.
+        assert qsize == (count - n - 2) + 1
 
 
 def test_http_path_from_absolute_target() -> None:

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -22,6 +22,7 @@ from quart.globals import g
 from quart.globals import request
 from quart.globals import websocket
 from quart.routing import QuartRule
+from quart.testing import make_test_body_chunks
 from quart.testing import make_test_headers_path_and_query_string
 from quart.testing import no_op_push
 from quart.wrappers import Request
@@ -42,6 +43,7 @@ async def test_request_context_match(http_scope: HTTPScope) -> None:
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     async with RequestContext(app, request):
@@ -63,6 +65,7 @@ async def test_bad_request_if_websocket_route(http_scope: HTTPScope) -> None:
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     async with RequestContext(app, request):
@@ -83,6 +86,7 @@ async def test_after_this_request(http_scope: HTTPScope) -> None:
             "",
             "1.1",
             http_scope,
+            body_chunks=make_test_body_chunks(),
             send_push_promise=no_op_push,
         ),
     ) as context:
@@ -102,6 +106,7 @@ async def test_has_request_context(http_scope: HTTPScope) -> None:
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     async with RequestContext(Quart(__name__), request):

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -4,6 +4,7 @@ import pytest
 from werkzeug.exceptions import RequestEntityTooLarge
 
 from quart.formparser import MultiPartParser
+from quart.testing import make_test_body_chunks
 from quart.wrappers.request import Body
 
 
@@ -11,8 +12,8 @@ async def test_multipart_max_form_memory_size() -> None:
     """max_form_memory_size is tracked across multiple data events."""
     data = b"--bound\r\nContent-Disposition: form-field; name=a\r\n\r\n"
     data += b"a" * 15 + b"\r\n--bound--"
-    body = Body(None, None)
-    body.set_result(data)
+    body_chunks = make_test_body_chunks(data)
+    body = Body(body_chunks, None, None)
     # The buffer size is less than the max size, so multiple data events will be
     # returned. The field size is greater than the max.
     parser = MultiPartParser(max_form_memory_size=10, buffer_size=5)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7,6 +7,7 @@ from hypercorn.typing import HTTPScope
 from werkzeug.datastructures import Headers
 
 from quart.routing import QuartMap
+from quart.testing import make_test_body_chunks
 from quart.testing import no_op_push
 from quart.wrappers.request import Request
 
@@ -28,6 +29,7 @@ async def test_bind_warning(
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -8,6 +8,7 @@ from werkzeug.datastructures import Headers
 from quart.app import Quart
 from quart.sessions import SecureCookieSession
 from quart.sessions import SecureCookieSessionInterface
+from quart.testing import make_test_body_chunks
 from quart.testing import no_op_push
 from quart.wrappers import Request
 from quart.wrappers import Response
@@ -32,6 +33,7 @@ async def test_secure_cookie_session_interface_open_session(
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     request.headers["Cookie"] = response.headers["Set-Cookie"]

--- a/tests/wrappers/test_request.py
+++ b/tests/wrappers/test_request.py
@@ -9,31 +9,37 @@ from werkzeug.datastructures import Headers
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.exceptions import RequestTimeout
 
+from quart.testing import make_test_body_chunks
 from quart.testing import no_op_push
+from quart.utils import AsyncQueueIterator
 from quart.wrappers.request import Body
 from quart.wrappers.request import Request
 
 
-async def _fill_body(body: Body, semaphore: asyncio.Semaphore, limit: int) -> None:
+async def _fill_body(
+    body_chunks: AsyncQueueIterator[bytes], semaphore: asyncio.Semaphore, limit: int
+) -> None:
     for number in range(limit):
-        body.append(b"%d" % number)
+        await body_chunks.put(b"%d" % number)
         await semaphore.acquire()
-    body.set_complete()
+    body_chunks.set_complete()
 
 
 async def test_full_body() -> None:
-    body = Body(None, None)
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, None)
     limit = 3
     semaphore = asyncio.Semaphore(limit)
-    asyncio.ensure_future(_fill_body(body, semaphore, limit))
+    asyncio.ensure_future(_fill_body(body_chunks, semaphore, limit))
     assert b"012" == await body
 
 
 async def test_body_streaming() -> None:
-    body = Body(None, None)
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, None)
     limit = 3
     semaphore = asyncio.Semaphore(0)
-    asyncio.ensure_future(_fill_body(body, semaphore, limit))
+    asyncio.ensure_future(_fill_body(body_chunks, semaphore, limit))
     index = 0
     async for data in body:
         semaphore.release()
@@ -42,10 +48,22 @@ async def test_body_streaming() -> None:
     assert b"" == await body
 
 
+async def test_body_streaming_backpressure() -> None:
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, None)
+    limit = 3
+    semaphore = asyncio.Semaphore(2)  # will be locked if more than 1 chunk queued
+    asyncio.ensure_future(_fill_body(body_chunks, semaphore, limit))
+    async for _ in body:
+        assert not semaphore.locked()  # only 1 chunk was accepted from source
+        semaphore.release()
+
+
 async def test_body_stream_single_chunk() -> None:
-    body = Body(None, None)
-    body.append(b"data")
-    body.set_complete()
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, None)
+    body_chunks.put_nowait(b"data")
+    body_chunks.set_complete()
 
     async def _check_data() -> None:
         async for data in body:
@@ -55,9 +73,10 @@ async def test_body_stream_single_chunk() -> None:
 
 
 async def test_body_streaming_no_data() -> None:
-    body = Body(None, None)
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, None)
     semaphore = asyncio.Semaphore(0)
-    asyncio.ensure_future(_fill_body(body, semaphore, 0))
+    asyncio.ensure_future(_fill_body(body_chunks, semaphore, 0))
     async for _ in body:  # noqa: F841
         raise AssertionError("Should not reach this line")
     assert b"" == await body
@@ -65,8 +84,9 @@ async def test_body_streaming_no_data() -> None:
 
 async def test_body_exceeds_max_content_length() -> None:
     max_content_length = 5
-    body = Body(None, max_content_length)
-    body.append(b" " * (max_content_length + 1))
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
+    body = Body(body_chunks, None, max_content_length)
+    body_chunks.put_nowait(b" " * (max_content_length + 1))
     with pytest.raises(RequestEntityTooLarge):
         await body
 
@@ -85,6 +105,7 @@ async def test_request_exceeds_max_content_length(http_scope: HTTPScope) -> None
         "1.1",
         http_scope,
         max_content_length=max_content_length,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     with pytest.raises(RequestEntityTooLarge):
@@ -92,6 +113,7 @@ async def test_request_exceeds_max_content_length(http_scope: HTTPScope) -> None
 
 
 async def test_request_get_data_timeout(http_scope: HTTPScope) -> None:
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
     request = Request(
         "POST",
         "http",
@@ -102,6 +124,7 @@ async def test_request_get_data_timeout(http_scope: HTTPScope) -> None:
         "1.1",
         http_scope,
         body_timeout=1,
+        body_chunks=body_chunks,
         send_push_promise=no_op_push,
     )
     with pytest.raises(RequestTimeout):
@@ -115,6 +138,7 @@ async def test_request_get_data_timeout(http_scope: HTTPScope) -> None:
 async def test_request_values(
     method: str, expected: list[str], http_scope: HTTPScope
 ) -> None:
+    body_chunks: AsyncQueueIterator[bytes] = AsyncQueueIterator(1)
     request = Request(
         method,
         "http",
@@ -126,10 +150,11 @@ async def test_request_values(
         "",
         "1.1",
         http_scope,
+        body_chunks=body_chunks,
         send_push_promise=no_op_push,
     )
-    request.body.append(urlencode({"a": "d"}).encode())
-    request.body.set_complete()
+    body_chunks.put_nowait(urlencode({"a": "d"}).encode())
+    body_chunks.set_complete()
     assert (await request.values).getlist("a") == expected
 
 
@@ -157,6 +182,7 @@ async def test_request_send_push_promise(http_scope: HTTPScope) -> None:
         "",
         "2",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=_push,
     )
     await request.send_push_promise("/")

--- a/tests/wrappers/test_response.py
+++ b/tests/wrappers/test_response.py
@@ -14,6 +14,7 @@ from hypothesis import strategies as strategies
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import RequestedRangeNotSatisfiable
 
+from quart.testing import make_test_body_chunks
 from quart.testing import no_op_push
 from quart.typing import HTTPScope
 from quart.wrappers import Request
@@ -96,6 +97,7 @@ async def test_response_make_conditional(http_scope: HTTPScope) -> None:
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     response = Response(b"abcdef")
@@ -119,6 +121,7 @@ async def test_response_make_conditional_no_condition(http_scope: HTTPScope) -> 
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     response = Response(b"abcdef")
@@ -137,6 +140,7 @@ async def test_response_make_conditional_out_of_bound(http_scope: HTTPScope) -> 
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     response = Response(b"abcdef")
@@ -157,6 +161,7 @@ async def test_response_make_conditional_not_modified(http_scope: HTTPScope) -> 
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     await response.make_conditional(request)
@@ -181,6 +186,7 @@ async def test_response_make_conditional_not_satisfiable(
         "",
         "1.1",
         http_scope,
+        body_chunks=make_test_body_chunks(),
         send_push_promise=no_op_push,
     )
     response = Response(b"abcdef")


### PR DESCRIPTION
HTTP request body chunks and WebSocket messages will be received from the underlying ASGI server only as fast as the application is able to handle them.  Previously, input would be read from the client as quickly as possible, and would be buffered in memory if the application's handler didn't consume it fast enough.  Now, the amount of input buffered in memory is limited to a single HTTP body chunk or WebSocket message, instead of being unbounded.

I originally intended to remove the connections' `receiver_task` entirely, and just call the ASGI receive function directly from `handler_task`, as I'd mentioned in a comment on #152.  However, I realized that it's sufficient to just have `receiver_task` wait for space to be available in a bounded queue instead of immediately appending to unbounded storage.

This involved some changes for HTTP to make it use a queue instead of a byte array.  The `Body` class no longer has methods to append chunks of data or signal completion, because it no longer owns the storage for the data; those methods are now on a separate queue object, and the `Body` just reads from the queue (via an iterator).  In hindsight I could've had the body object own the queue so it could still have methods like `append` and `set_complete`, but it seems cleaner this way, and it's closer to how WebSocket is implemented.

The change for WebSocket is much simpler, because it already uses a queue, which just needed to have a size limit instead of being unbounded.

Note that if the client disconnects unexpectedly, the handler task might not be canceled immediately if there's pending input that the app's handler hasn't taken from the queue yet.  Previously the receiver task was always ready to immediately get new events from the ASGI receive function so it would notice a disconnect right away, but now it has to wait for space in the queue when putting a data chunk into it, before it can get the next event from ASGI.  However, backpressure means that there won't be a large amount of input queued up, so the handler task will be canceled in a timely manner once it starts consuming its input.

Fixes #152
