### PR TITLE
fix pathlib dependency bug in tutorial

### DIFF
--- a/examples/blog/src/blog/__init__.py
+++ b/examples/blog/src/blog/__init__.py
@@ -1,4 +1,5 @@
 from sqlite3 import dbapi2 as sqlite3
+from pathlib import Path
 
 from quart import g
 from quart import Quart
@@ -11,7 +12,7 @@ app = Quart(__name__)
 
 app.config.update(
     {
-        "DATABASE": app.root_path / "blog.db",
+        "DATABASE": Path(app.root_path) / "blog.db",
     }
 )
 
@@ -57,7 +58,7 @@ async def create():
 
 def init_db():
     db = _connect_db()
-    with open(app.root_path / "schema.sql") as file_:
+    with open(Path(app.root_path) / "schema.sql") as file_:
         db.cursor().executescript(file_.read())
     db.commit()
 

--- a/examples/blog/src/blog/__init__.py
+++ b/examples/blog/src/blog/__init__.py
@@ -1,5 +1,5 @@
-from sqlite3 import dbapi2 as sqlite3
 from pathlib import Path
+from sqlite3 import dbapi2 as sqlite3
 
 from quart import g
 from quart import Quart


### PR DESCRIPTION
The associated issue (#347) and its linked pull request (#348) did not resolve the problem. 

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; from importlib import import_module; sys.argv = ['/home/duzhuo/.pyenv/versions/3.14.0b1/envs/3.14-test/bin/start']; sys.exit(import_module('blog').run())
                                                                                                                                             ~~~~~~~~~~~~~^^^^^^^^
  File "/home/duzhuo/.pyenv/versions/3.14.0b1/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 762, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "/home/duzhuo/src/quart/examples/blog/src/blog/__init__.py", line 16, in <module>
    "DATABASE": app.root_path / "blog.db",
                ~~~~~~~~~~~~~~^~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

I've resubmitted working code that aligns with the official tutorial (https://quart.palletsprojects.com/en/latest/tutorials/blog_tutorial.html).