### PR TITLE
Fix broken contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ follow our [contributing guide].
 
 [GitHub]: https://github.com/pallets/quart
 [issue]: https://github.com/pallets/quart/issues
-[contributing guide]: https://github.com/pallets/quart/CONTRIBUTING.rst
+[contributing guide]: https://github.com/pallets/quart/CONTRIBUTING.md
 
 ## Help
 


### PR DESCRIPTION
💁 The file extension of this URL wasn't updated in https://github.com/pallets/quart/pull/386. This change fixes that.