### PR TITLE
Detect non-port-needing URI schemes and use the correct configuration

### DIFF
--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -919,7 +919,10 @@ class Quart(App):
         config = HyperConfig()
         config.access_log_format = "%(h)s %(r)s %(s)s %(b)s %(D)s"
         config.accesslog = "-"
-        config.bind = [f"{host}:{port}"]
+        if host.startswith("unix:") or host.startswith("fd:"):
+            config.bind = [f"{host}"]
+        else:
+            config.bind = [f"{host}:{port}"]
         config.ca_certs = ca_certs
         config.certfile = certfile
         if debug is not None:


### PR DESCRIPTION
Hello! 

Thanks you kindly for your work on Quart. This pull request addresses #439 by detecting [URI schemes that don't use a port number](https://hypercorn.readthedocs.io/en/latest/how_to_guides/configuring.html#configuration-options) and passing the correct configuration to the `bind` option.

fixes #439
