### PR TITLE
[CLI] Add `--debug/--no-debug` flag to `quart run`

### DIFF
--- a/src/quart/cli.py
+++ b/src/quart/cli.py
@@ -663,6 +663,9 @@ def run_command(
     )
 
 
+run_command.params.insert(0, _debug_option)
+
+
 @click.command("shell", short_help="Run a shell in the app context.")
 @with_appcontext
 def shell_command() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,3 +132,29 @@ def test_load_dotenv_beats_dotquartenv(empty_cwd: Path) -> None:
     load_dotenv()
 
     assert os.environ.pop("TEST_ENV_VAR", None) == env_value
+
+
+def test_run_command_debug_option(app: Mock) -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["--app", "module:app", "run", "--debug"])
+    app.run.assert_called_once_with(
+        debug=True,
+        host="127.0.0.1",
+        port=5000,
+        certfile=None,
+        keyfile=None,
+        use_reloader=True,
+    )
+
+
+def test_run_command_no_debug_option(dev_app: Mock) -> None:
+    runner = CliRunner()
+    runner.invoke(cli, ["--app", "module:app", "run", "--no-debug"])
+    dev_app.run.assert_called_once_with(
+        debug=False,
+        host="127.0.0.1",
+        port=5000,
+        certfile=None,
+        keyfile=None,
+        use_reloader=False,
+    )


### PR DESCRIPTION
This PR brings Quart's CLI in line with Flask's by exposing an explicit `--debug/--no-debug` option on the `quart run` command.
```
Usage: quart run [OPTIONS]

  Run a local development server.

Options:
  --debug / --no-debug     Set 'app.debug' separately from '--env'.
  -h, --host TEXT          The interface to bind to.
  -p, --port INTEGER       The port to bind to.
  --certfile, --cert FILE  Specify a certificate file to use HTTPS.
  --keyfile, --key FILE    The key file to use when specifying a certificate.
  --reload / --no-reload   Enable or disable the reloader
  --help                   Show this message and exit.
```
Tests added.

fixes #354 