### PR TITLE
Adds type to the `Request.files` docs

### DIFF
--- a/src/quart/wrappers/request.py
+++ b/src/quart/wrappers/request.py
@@ -18,6 +18,7 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.exceptions import RequestTimeout
 
+from ..datastructures import FileStorage
 from ..formparser import FormDataParser
 from ..globals import current_app
 from .base import BaseRequestWebsocket
@@ -316,13 +317,12 @@ class Request(BaseRequestWebsocket):
         return self._form
 
     @property
-    async def files(self) -> MultiDict:
+    async def files(self) -> MultiDict[str, FileStorage]:
         """The parsed files.
 
         This will return an empty multidict unless the request
         mimetype was ``enctype="multipart/form-data"`` and the method
-        POST, PUT, or PATCH; in that case the type of values in the
-        multidict is ``FileStorage``.
+        POST, PUT, or PATCH.
         """
         await self._load_form_data()
         return self._files

--- a/src/quart/wrappers/request.py
+++ b/src/quart/wrappers/request.py
@@ -321,7 +321,8 @@ class Request(BaseRequestWebsocket):
 
         This will return an empty multidict unless the request
         mimetype was ``enctype="multipart/form-data"`` and the method
-        POST, PUT, or PATCH.
+        POST, PUT, or PATCH; in that case the type of values in the
+        multidict is ``FileStorage``.
         """
         await self._load_form_data()
         return self._files


### PR DESCRIPTION
I was wondering what type `Request.files` would return (I mean, the type inside the multidict). That wasn't present in the docs, so I suggest adding it : )
