### PR TITLE
GitHub Actions: Add Python 3.14 and 3.14t to the testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,9 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {python: '3.14t'}
+          - {python: '3.14'}
+          - {name: Windows, python: '3.14', os: windows-latest}
+          - {name: Mac, python: '3.14', os: macos-latest}
           - {python: '3.13'}
-          - {name: Windows, python: '3.13', os: windows-latest}
-          - {name: Mac, python: '3.13', os: macos-latest}
           - {python: '3.12'}
           - {python: '3.11'}
           - {python: '3.10'}


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

https://py-free-threading.github.io/porting