### PR TITLE
Add Quart-Enciphers to extensions list

### DIFF
--- a/docs/how_to_guides/quart_extensions.rst
+++ b/docs/how_to_guides/quart_extensions.rst
@@ -52,6 +52,8 @@ here,
 - `Quart-LibreTranslate <https://github.com/Quart-Addons/quart-libretranslate>`_ Simple integration to
   use LibreTranslate with your Quart app.
 - `Quart-Uploads <https://github.com/Quart-Addons/quart-uploads>`_ File upload handling for Quart.
+`Quart-Enciphers <https://pypi.org/project/quart-enciphers/>`_
+   Encrypted cookie session using enciphers.
 
 Supporting sync code in a Quart Extension
 -----------------------------------------


### PR DESCRIPTION
Add Quart-Enciphers to the list of Quart extensions.

Quart-Enciphers is a session interface that replaces the default  signed cookie with a fully encrypted one using the enciphers library  (Rust-powered, 10x faster than Fernet).

- PyPI: https://pypi.org/project/quart-enciphers/
- GitHub: https://github.com/mjlad/quart-enciphers
- License: Apache-2.0

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->
