### PR TITLE
Fix ASGI middleware assignment typing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Released 2026-07-23
   <https://github.com/pallets/flask/security/advisories/GHSA-4grg-w6v8-c28g>
 - Support partitioned cookies
 - Don't apply max_form_parts to non-multipart forms
+- Allow assigning ASGI middleware to ``asgi_app`` without type errors.
 
 ## Version 0.20.0
 

--- a/src/quart/app.py
+++ b/src/quart/app.py
@@ -20,6 +20,7 @@ from typing import cast
 from typing import NoReturn
 from typing import overload
 from typing import ParamSpec
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from urllib.parse import quote
 
@@ -94,6 +95,7 @@ from .testing import sentinel
 from .testing import TestApp
 from .typing import AfterServingCallable
 from .typing import AfterWebsocketCallable
+from .typing import ASGIApp
 from .typing import ASGIHTTPProtocol
 from .typing import ASGILifespanProtocol
 from .typing import ASGIWebsocketProtocol
@@ -1735,31 +1737,37 @@ class Quart(App):
         """
         await self.asgi_app(scope, receive, send)
 
-    async def asgi_app(
-        self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
-    ) -> None:
-        """This handles ASGI calls, it can be wrapped in middleware.
+    if TYPE_CHECKING:
+        asgi_app: ASGIApp
+    else:
 
-        When using middleware with Quart it is preferable to wrap this
-        method rather than the app itself. This is to ensure that the
-        app is an instance of this class - which allows the quart cli
-        to work correctly. To use this feature simply do,
+        async def asgi_app(
+            self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        ) -> None:
+            """This handles ASGI calls, it can be wrapped in middleware.
 
-        .. code-block:: python
+            When using middleware with Quart it is preferable to wrap this
+            method rather than the app itself. This is to ensure that the
+            app is an instance of this class - which allows the quart cli
+            to work correctly. To use this feature simply do,
 
-            app.asgi_app = middleware(app.asgi_app)
+            .. code-block:: python
 
-        """
-        asgi_handler: ASGIHTTPProtocol | ASGILifespanProtocol | ASGIWebsocketProtocol
-        if scope["type"] == "http":
-            asgi_handler = self.asgi_http_class(self, scope)
-        elif scope["type"] == "websocket":
-            asgi_handler = self.asgi_websocket_class(self, scope)
-        elif scope["type"] == "lifespan":
-            asgi_handler = self.asgi_lifespan_class(self, scope)
-        else:
-            raise RuntimeError("ASGI Scope type is unknown")
-        await asgi_handler(receive, send)
+                app.asgi_app = middleware(app.asgi_app)
+
+            """
+            asgi_handler: (
+                ASGIHTTPProtocol | ASGILifespanProtocol | ASGIWebsocketProtocol
+            )
+            if scope["type"] == "http":
+                asgi_handler = self.asgi_http_class(self, scope)
+            elif scope["type"] == "websocket":
+                asgi_handler = self.asgi_websocket_class(self, scope)
+            elif scope["type"] == "lifespan":
+                asgi_handler = self.asgi_lifespan_class(self, scope)
+            else:
+                raise RuntimeError("ASGI Scope type is unknown")
+            await asgi_handler(receive, send)
 
     async def startup(self) -> None:
         self.shutdown_event = self.event_class()

--- a/src/quart/typing.py
+++ b/src/quart/typing.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .wrappers.response import Response  # noqa: F401
 
 FilePath = bytes | str | os.PathLike
+ASGIApp = Callable[[Any, Any, Any], Awaitable[None]]
 
 # The possible types that are directly convertible or are a Response object.
 ResponseValue = Union[

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -458,7 +458,7 @@ async def test_middleware() -> None:
             else:
                 await self.app(scope, receive, send)
 
-    app.asgi_app = OddMiddleware(app.asgi_app)  # type: ignore
+    app.asgi_app = OddMiddleware(app.asgi_app)
 
     client = app.test_client()
     response = await client.get("/")


### PR DESCRIPTION
Fixes #438.

The documented `app.asgi_app = middleware(app.asgi_app)` pattern was treated by
type checkers as assignment to a method. This keeps the existing runtime method
unchanged while exposing an assignable ASGI application callable during static
type checking.

The existing middleware test now verifies the assignment without a type-ignore,
and the original OpenTelemetry example from the issue passes mypy.

Validation:

- `pytest`: 256 passed
- `mypy` on the OpenTelemetry reproduction: no issues found
- Ruff check and format: passed
- pre-commit: passed
- `git diff --check`: passed

Full-project mypy on Windows retains one existing `readline.set_completer`
platform error; no new errors are introduced by this change.
