### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix ``stream_with_context`` not propagating ``g`` into the generator.
+
 ## Version 0.21
 
 Released 2026-07-23

--- a/src/quart/helpers.py
+++ b/src/quart/helpers.py
@@ -25,6 +25,7 @@ from werkzeug.utils import redirect as werkzeug_redirect
 from werkzeug.utils import safe_join
 from werkzeug.wrappers import Response as WerkzeugResponse
 
+from .globals import _cv_app
 from .globals import _cv_request
 from .globals import current_app
 from .globals import request
@@ -203,9 +204,9 @@ def url_for(
 
 
 def stream_with_context(func: Callable) -> Callable:
-    """Share the current request context with a generator.
+    """Share the current request and app context with a generator.
 
-    This allows the request context to be accessed within a streaming
+    This allows the request context and ``g`` to be accessed within a streaming
     generator, for example,
 
     .. code-block:: python
@@ -222,10 +223,11 @@ def stream_with_context(func: Callable) -> Callable:
 
     """
     request_context = _cv_request.get().copy()
+    app_context = _cv_app.get().copy()
 
     @wraps(func)
     async def generator(*args: Any, **kwargs: Any) -> Any:
-        async with request_context:
+        async with app_context, request_context:
             async for data in func(*args, **kwargs):
                 yield data
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,8 +10,8 @@ import pytest
 from werkzeug.exceptions import NotFound
 
 from quart import Blueprint
-from quart import Quart
 from quart import g
+from quart import Quart
 from quart import request
 from quart.helpers import flash
 from quart.helpers import get_flashed_messages

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import NotFound
 
 from quart import Blueprint
 from quart import Quart
+from quart import g
 from quart import request
 from quart.helpers import flash
 from quart.helpers import get_flashed_messages
@@ -182,6 +183,25 @@ async def test_stream_with_context() -> None:
     response = await test_client.get("/")
     result = await response.get_data(as_text=False)
     assert result == b"GET /"
+
+
+async def test_stream_with_context_propagates_g() -> None:
+    app = Quart(__name__)
+
+    @app.route("/")
+    async def index() -> AsyncGenerator[bytes, None]:
+        g.marker = b"from-g"
+
+        @stream_with_context
+        async def generator() -> AsyncGenerator[bytes, None]:
+            yield g.marker
+
+        return generator()
+
+    test_client = app.test_client()
+    response = await test_client.get("/")
+    result = await response.get_data(as_text=False)
+    assert result == b"from-g"
 
 
 async def test_send_from_directory_raises() -> None:


### PR DESCRIPTION
`stream_with_context` copied only the request context. The generator is iterated later, after the original request task has popped its app context, so `_push_appctx` created a fresh empty `g`.

Copy the current app context as well (it already shares `g`) and restore both while streaming.

Fixes #361.